### PR TITLE
Updates to add a `attributesExcluded` param;

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,18 +13,18 @@
   var defaultStyles = ["display"];
   var defaultAttributes = ["style", "class"];
 
-  function normalizeHTML(node, attributesToConsider, stylesToConsider, classNamesToConsider) {
+  function normalizeHTML(node, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider) {
     var html = "";
 
     if (node.nodeType === 1) {
       var tagName = node.tagName.toLowerCase();
       html += "<" + tagName;
-      html += normalizeAttributes(node, attributesToConsider, stylesToConsider, classNamesToConsider);
+      html += normalizeAttributes(node, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
       html += ">";
 
       if (node.hasChildNodes()) {
         Array.prototype.slice.call(node.childNodes, 0).forEach(function (node) {
-          html += normalizeHTML(node, attributesToConsider, stylesToConsider, classNamesToConsider);
+          html += normalizeHTML(node, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
         });
       }
       html += "</" + tagName + ">";
@@ -39,7 +39,7 @@
     return html;
   }
 
-  function normalizeAttributes(node, attributesToConsider, stylesToConsider, classNamesToConsider) {
+  function normalizeAttributes(node, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider) {
     var attributes = "";
     var attributeList = Array.prototype.slice.call(node.attributes, 0).reduce(function (map, attribute) {
       map[attribute.nodeName] = attribute.nodeValue;
@@ -48,9 +48,11 @@
 
     Object.keys(attributeList).sort().forEach(function (attributeKey) {
       var value = attributeList[attributeKey];
+      var lowerCasedAttributeKey = attributeKey.toLowerCase();
 
-      if (!attributesToConsider || //if null consider all attributes
-      attributesToConsider[attributeKey.toLowerCase()]) {
+      if (!attributesToConsider || // if null consider all attributes
+          ( attributesToConsider[lowerCasedAttributeKey] &&
+            !attributesToExclude[lowerCasedAttributeKey])) { // check the black list
 
         if (attributeKey === "style") {
           attributes += normalizeStyle(value, stylesToConsider);
@@ -138,21 +140,21 @@
     return normalized;
   }
 
-  function normalizedHTMLFromReactComponent(reactComponent, attributesToConsider, stylesToConsider, classNamesToConsider) {
+  function normalizedHTMLFromReactComponent(reactComponent, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider) {
     var domString = React.renderToStaticMarkup(reactComponent);
 
-    return normalizeHTMLString(domString, attributesToConsider, stylesToConsider, classNamesToConsider);
+    return normalizeHTMLString(domString, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
   }
 
-  function normalizeHTMLString(domString, attributesToConsider, stylesToConsider, classNamesToConsider) {
+  function normalizeHTMLString(domString, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider) {
     var holderNode = doc.createElement("div");
     holderNode.innerHTML = domString;
-    var normalized = normalizeHTML(holderNode.children[0], attributesToConsider, stylesToConsider, classNamesToConsider);
+    var normalized = normalizeHTML(holderNode.children[0], attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
 
     return normalized;
   }
 
-  function normalizeHTMLFromReactView(reactView, attributesToConsider, stylesToConsider, classNamesToConsider) {
+  function normalizeHTMLFromReactView(reactView, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider) {
     var domNode;
 
     try {
@@ -161,7 +163,7 @@
       domNode = reactView.getDOMNode();
     }
 
-    return normalizeHTML(domNode, attributesToConsider, stylesToConsider, classNamesToConsider);
+    return normalizeHTML(domNode, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
   }
 
   function toLowerMap(array) {
@@ -195,6 +197,10 @@
       options.attributes = defaultAttributes;
     }
 
+    if (!options.hasOwnProperty("attributesExcluded")) {
+      options.attributesExcluded = [];
+    }
+
     if (!options.hasOwnProperty("styles")) {
       options.styles = defaultStyles;
     }
@@ -204,6 +210,7 @@
     }
 
     var attributesToConsider = options.attributes ? toLowerMap(options.attributes) : null;
+    var attributesToExclude = options.attributesExcluded ? toLowerMap(options.attributesExcluded) : null;
     var classNamesToConsider = options.classNames ? toMap(options.classNames) : null;
     var stylesToConsider = options.styles ? toLowerMap(options.styles) : null;
 
@@ -215,7 +222,7 @@
           throw new Error("This function takes one argument.  It must be a react view and can not be null.");
         }
 
-        return normalizeHTMLFromReactView(view, attributesToConsider, stylesToConsider, classNamesToConsider);
+        return normalizeHTMLFromReactView(view, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
       },
       reactComponent: function reactComponent(component) {
         if (isReactView(component)) {
@@ -224,21 +231,21 @@
           throw new Error("This function takes one argument.  It must be a react component and can not be null.");
         }
 
-        return normalizedHTMLFromReactComponent(component, attributesToConsider, stylesToConsider, classNamesToConsider);
+        return normalizedHTMLFromReactComponent(component, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
       },
       domNode: function domNode(node) {
         if (!node || typeof node !== "object" || node.innerHTML === undefined) {
           throw new Error("This function takes one argument.  It must be a dom node and can not be null.");
         }
 
-        return normalizeHTML(node, attributesToConsider, stylesToConsider, classNamesToConsider);
+        return normalizeHTML(node, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
       },
       domString: function domString(string) {
         if (!string || typeof string !== "string") {
           throw new Error("This function takes one argument.  It must be a dom string and can not be empty.");
         }
 
-        return normalizeHTMLString(string, attributesToConsider, stylesToConsider, classNamesToConsider);
+        return normalizeHTMLString(string, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
       },
       normalize: function normalize(objectWithHTML) {
         if (objectWithHTML && typeof objectWithHTML === "string") {


### PR DESCRIPTION
I have finished the basic updates for an exclusion array passed in, but I haven't yet been able to work on the tests inside of the normalizer package. It passes tests in my app, and doesn't break the existing tests in any way.

When creating a new normalizer you would now be able to pass in an `attributesExcluded` option with an array of attributes that will be blacklisted during normalization.

Example:

```
var normalizer = new Normalizer({ "attributes": null, "attributesExcluded": ["data-a"] });
```

Please let me know if you have any questions or concerns. Feel free to make this idea whatever you want. :smile:

(P.S.: If you have time to help me with the tests, that's great. I have a busy day tomorrow.)
