### PR TITLE
Attributes blacklist feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,12 @@ expect(actual).toEqual(expected);
 ### White listing styles and attributes.
 
 Normalizer's constructor `Normalizer({})` takes an optional hash with the following optional properties:
-* *attributes* Array of attribute names to keep when normalizing the HTML.  Defaults to `["style", "class"]`
-* *styles* Array of style names to keep when normalizing the HTML.  Defaults to `["display"]`
+* *attributes* Array of attribute names to keep when normalizing the HTML.  Defaults to `["style", "class"]`;
+* *attributesExcluded* Array of attribute names to exclude when normalizing the HTML. Defaults to `[]`;
+* *styles* Array of style names to keep when normalizing the HTML.  Defaults to `["display"]`;
 * *classNames* Array of class names to keep when normalizing the HTML.  Defaults to `null`.
 
-**NOTE:**  For all options use null to include all; use an empty array to include none. For example the `Normalizer({attributes: null, styles: null, classNames: null})` will compare all attributes, styles and classes.  `Normalizer({attributes: [], styles: [], classNames: []})` will only compare the DOM nodes and ignore all attributes, styles and classes.
+**NOTE:**  For all options use null to include all (except for *attributesExcluded*, for this case it will act like empty array); use an empty array to include none. For example the `Normalizer({attributes: null, attributesExcluded: null, styles: null, classNames: null})` will compare all attributes, styles and classes.  `Normalizer({attributes: [], styles: [], classNames: []})` will only compare the DOM nodes and ignore all attributes, styles and classes. `Normalizer({attributes: null, attributesExcluded: ['data-state'], styles: null, classNames: null})` will compare all styles, classes and all attributes except for *data-state*.
 
 
 

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@
       options.attributes = defaultAttributes;
     }
 
-    if (!options.hasOwnProperty("attributesExcluded")) {
+    if (!options.hasOwnProperty("attributesExcluded") || options.attributesExcluded === null) {
       options.attributesExcluded = [];
     }
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 "use strict";
 
-(function(factory) {   
+(function(factory) {
   if (typeof exports !== 'undefined') {
     var React = require('react');
     var jsdom = require('jsdom').jsdom;
-    var doc = jsdom('jsdom document'); 
-    module.exports = factory(React, doc); 
+    var doc = jsdom('jsdom document');
+    module.exports = factory(React, doc);
   } else {
     window.Normalizer = { Normalizer: factory(window.React, window.document) }; // jshint ignore:line
   }
@@ -14,17 +14,17 @@
   var defaultStyles = ["display"];
   var defaultAttributes = ["style", "class"];
 
-  function normalizeHTML(node, attributesToConsider, stylesToConsider, classNamesToConsider){
+  function normalizeHTML(node, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider) {
     var html = "";
 
     if (node.nodeType === 1) {
       var tagName = node.tagName.toLowerCase();
       html += "<"+tagName;
-      html += normalizeAttributes(node, attributesToConsider, stylesToConsider, classNamesToConsider);
+      html += normalizeAttributes(node, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
       html += ">";
 
       if(node.hasChildNodes()){
-        Array.prototype.slice.call(node.childNodes,0).forEach(node => {html += normalizeHTML(node, attributesToConsider, stylesToConsider, classNamesToConsider);});
+        Array.prototype.slice.call(node.childNodes,0).forEach(node => {html += normalizeHTML(node, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);});
       }
       html += "</"+tagName+">";
     }
@@ -32,14 +32,14 @@
       var nodeValue = node.nodeValue.replace(/\s+/g, ' ');
 
       if(nodeValue.trim()){
-        html += nodeValue;  
+        html += nodeValue;
       }
     }
 
     return html;
   }
 
-  function normalizeAttributes(node, attributesToConsider, stylesToConsider, classNamesToConsider){
+  function normalizeAttributes(node, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider) {
     var attributes = "";
     var attributeList = Array.prototype.slice.call(node.attributes, 0).reduce(((map, attribute) => {
       map[attribute.nodeName] = attribute.nodeValue;
@@ -48,9 +48,10 @@
 
     Object.keys(attributeList).sort().forEach((attributeKey) => {
       var value = attributeList[attributeKey];
+      var lowerCasedAttributeKey = attributeKey.toLowerCase();
 
-      if(! attributesToConsider || //if null consider all attributes 
-        attributesToConsider[attributeKey.toLowerCase()]){
+      if (!attributesToExclude[lowerCasedAttributeKey] && // checking blacklist
+        (!attributesToConsider || attributesToConsider[lowerCasedAttributeKey])) {
 
           if(attributeKey === "style"){
             attributes += normalizeStyle(value, stylesToConsider);
@@ -81,8 +82,8 @@
           if(!normalized){
             normalized = "class=\"";
           }
-          
-          normalized += className + " ";      
+
+          normalized += className + " ";
         }
 
         return normalized;
@@ -91,7 +92,7 @@
       if(retVal){
         retVal = retVal.trim();
         retVal = " " + retVal + "\"";
-      } 
+      }
     }
 
     return retVal;
@@ -141,31 +142,31 @@
     return normalized;
   }
 
-  function normalizedHTMLFromReactComponent(reactComponent, attributesToConsider, stylesToConsider, classNamesToConsider){
+  function normalizedHTMLFromReactComponent(reactComponent, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider) {
     var domString = React.renderToStaticMarkup(reactComponent);
-    
-    return normalizeHTMLString(domString, attributesToConsider, stylesToConsider, classNamesToConsider);
+
+    return normalizeHTMLString(domString, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
   }
 
-  function normalizeHTMLString(domString, attributesToConsider, stylesToConsider, classNamesToConsider){
+  function normalizeHTMLString(domString, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider) {
     var holderNode = doc.createElement("div");
     holderNode.innerHTML = domString;
-    var normalized = normalizeHTML(holderNode.children[0], attributesToConsider, stylesToConsider, classNamesToConsider);
+    var normalized = normalizeHTML(holderNode.children[0], attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
 
     return normalized;
   }
 
-  function normalizeHTMLFromReactView(reactView, attributesToConsider, stylesToConsider, classNamesToConsider){
+  function normalizeHTMLFromReactView(reactView, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider) {
       var domNode;
 
       try {
         domNode = React.findDOMNode(reactView);
-      } 
+      }
       catch(e) {
         domNode = reactView.getDOMNode();
       }
 
-      return normalizeHTML(domNode, attributesToConsider, stylesToConsider, classNamesToConsider);
+      return normalizeHTML(domNode, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
   }
 
   function toLowerMap(array){
@@ -183,7 +184,7 @@
   }
 
   function isReactComponent(component){
-    return  component && 
+    return  component &&
             typeof component === "object" &&
             component.key !== undefined &&
             component.props !== undefined &&
@@ -191,7 +192,7 @@
   }
 
   function isReactView(view){
-    return  view && 
+    return  view &&
             typeof view === "object" &&
             view.state !== undefined &&
             view.props !== undefined &&
@@ -207,6 +208,10 @@
       options.attributes = defaultAttributes;
     }
 
+    if (!options.hasOwnProperty("attributesExcluded")) {
+      options.attributesExcluded = [];
+    }
+
     if(!options.hasOwnProperty("styles")){
       options.styles = defaultStyles;
     }
@@ -216,60 +221,61 @@
     }
 
     var attributesToConsider = options.attributes ? toLowerMap(options.attributes) : null;
+    var attributesToExclude = options.attributesExcluded ? toLowerMap(options.attributesExcluded) : null;
     var classNamesToConsider = options.classNames ? toMap(options.classNames) : null;
     var stylesToConsider = options.styles ? toLowerMap(options.styles) : null;
- 
+
     return {
         reactView(view){
           if(isReactComponent(view)){
             throw new Error("Looks like you passed in a react component.  Try using .reactComponent instead of .reactView.");
           }
-          else if(!isReactView(view)){ 
+          else if(!isReactView(view)){
             throw new Error("This function takes one argument.  It must be a react view and can not be null.");
           }
 
-          return normalizeHTMLFromReactView(view, attributesToConsider, stylesToConsider, classNamesToConsider);
+          return normalizeHTMLFromReactView(view, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
         },
         reactComponent(component){
             if(isReactView(component)){
               throw new Error("Looks like you passed in a react view.  Try using .reactView instead of .reactComponent.");
             }
-            else if(!isReactComponent(component)){ 
+            else if(!isReactComponent(component)){
               throw new Error("This function takes one argument.  It must be a react component and can not be null.");
             }
 
-            return normalizedHTMLFromReactComponent(component, attributesToConsider, stylesToConsider, classNamesToConsider);
+            return normalizedHTMLFromReactComponent(component, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
         },
         domNode(node){
             if(!node || typeof node !== "object" || node.innerHTML === undefined){
               throw new Error("This function takes one argument.  It must be a dom node and can not be null.");
             }
 
-            return normalizeHTML(node, attributesToConsider, stylesToConsider, classNamesToConsider);
+            return normalizeHTML(node, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
         },
         domString(string){
             if(!string || typeof string !== "string" ){
               throw new Error("This function takes one argument.  It must be a dom string and can not be empty.");
             }
 
-            return normalizeHTMLString(string, attributesToConsider, stylesToConsider, classNamesToConsider);
+            return normalizeHTMLString(string, attributesToConsider, attributesToExclude, stylesToConsider, classNamesToConsider);
         },
         normalize(objectWithHTML){
           if(objectWithHTML && typeof objectWithHTML === "string" ){
-            return this.domString(objectWithHTML); 
+            return this.domString(objectWithHTML);
           }else if(objectWithHTML && typeof objectWithHTML === "object" && objectWithHTML.innerHTML !== undefined){
-            return this.domNode(objectWithHTML); 
+            return this.domNode(objectWithHTML);
           }
           else if(isReactComponent(objectWithHTML)){
-            return this.reactComponent(objectWithHTML); 
+            return this.reactComponent(objectWithHTML);
           }
-          else if(isReactView(objectWithHTML)){ 
-            return this.reactView(objectWithHTML); 
+          else if(isReactView(objectWithHTML)){
+            return this.reactView(objectWithHTML);
           }
           else {
             throw new Error("This function takes one argument.  It must either be an HTML string, DOM node, react componenet or react element.");
           }
-            
+
         }
     };
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,9 +50,8 @@
       var value = attributeList[attributeKey];
       var lowerCasedAttributeKey = attributeKey.toLowerCase();
 
-      if (!attributesToConsider || // if null consider all attributes
-          ( attributesToConsider[lowerCasedAttributeKey] &&
-            !attributesToExclude[lowerCasedAttributeKey])) { // check the black list
+      if (!attributesToExclude[lowerCasedAttributeKey] && ( // checking blacklist
+      !attributesToConsider || attributesToConsider[lowerCasedAttributeKey])) {
 
         if (attributeKey === "style") {
           attributes += normalizeStyle(value, stylesToConsider);

--- a/lib/index.js
+++ b/lib/index.js
@@ -196,7 +196,7 @@
       options.attributes = defaultAttributes;
     }
 
-    if (!options.hasOwnProperty("attributesExcluded")) {
+    if (!options.hasOwnProperty("attributesExcluded") || options.attributesExcluded === null) {
       options.attributesExcluded = [];
     }
 

--- a/test/NormalizerSpec.js
+++ b/test/NormalizerSpec.js
@@ -11,7 +11,7 @@ chai.use(spies);
 function expectError(functionUnderTest, context, args) {
   var wrapped = function(){
     return functionUnderTest.apply(context,args);
-  }  
+  }
 
   return expect(wrapped);
 }
@@ -28,15 +28,15 @@ describe("Handling exceptions", (() => {
       expectedError = "This function takes one argument.  It must be a dom string and can not be empty.";
     });
 
-    it('triggers an exception when passing in an empty string', (() => { 
+    it('triggers an exception when passing in an empty string', (() => {
         expectError(normalizer.domString, normalizer, [""]).to.throw(expectedError);
-    })); 
+    }));
 
-    it('triggers an exception when passing in undefined', (() => { 
+    it('triggers an exception when passing in undefined', (() => {
         expect(normalizer.domString, normalizer).to.throw(expectedError);
     }));
 
-    it('triggers an exception when passing in an object', (() => { 
+    it('triggers an exception when passing in an object', (() => {
         expectError(normalizer.domString, normalizer, [{}]).to.throw(expectedError);
     }));
   }));
@@ -46,15 +46,15 @@ describe("Handling exceptions", (() => {
       expectedError = "This function takes one argument.  It must be a dom node and can not be null.";
     });
 
-    it('triggers an exception when passing in null', (() => { 
+    it('triggers an exception when passing in null', (() => {
         expectError(normalizer.domNode, normalizer, [null]).to.throw(expectedError);
-    })); 
+    }));
 
-    it('triggers an exception when passing in undefined', (() => { 
+    it('triggers an exception when passing in undefined', (() => {
         expect(normalizer.domNode, normalizer).to.throw(expectedError);
     }));
 
-    it('triggers an exception when passing in an object without an innerHTML property', (() => { 
+    it('triggers an exception when passing in an object without an innerHTML property', (() => {
         expectError(normalizer.domNode, normalizer, [{}]).to.throw(expectedError);
     }));
   }));
@@ -64,27 +64,27 @@ describe("Handling exceptions", (() => {
       expectedError = "This function takes one argument.  It must be a react component and can not be null.";
     });
 
-    it('triggers an exception when passing in null', (() => { 
+    it('triggers an exception when passing in null', (() => {
         expectError(normalizer.reactComponent, normalizer, [null]).to.throw(expectedError);
-    })); 
+    }));
 
-    it('triggers an exception when passing in undefined', (() => { 
+    it('triggers an exception when passing in undefined', (() => {
         expect(normalizer.reactComponent, normalizer).to.throw(expectedError);
     }));
 
-    it('triggers an exception when passing in an object without a key property', (() => { 
+    it('triggers an exception when passing in an object without a key property', (() => {
         expectError(normalizer.reactComponent, normalizer, [{}]).to.throw(expectedError);
     }));
 
-    it('triggers an exception when passing in an object without a prop property', (() => { 
+    it('triggers an exception when passing in an object without a prop property', (() => {
         expectError(normalizer.reactComponent, normalizer, [{}]).to.throw(expectedError);
     }));
 
-    it('triggers an exception when passing in an object without a ref property', (() => { 
+    it('triggers an exception when passing in an object without a ref property', (() => {
         expectError(normalizer.reactComponent, normalizer, [{}]).to.throw(expectedError);
     }));
 
-    it('triggers a hint exception when passing in a reactView', (() => { 
+    it('triggers a hint exception when passing in a reactView', (() => {
         var TestView = React.createClass({
                 render(){
                   return (<h1>YO</h1>);
@@ -103,27 +103,27 @@ describe("Handling exceptions", (() => {
       expectedError = "This function takes one argument.  It must be a react view and can not be null.";
     });
 
-    it('triggers an exception when passing in null', (() => { 
+    it('triggers an exception when passing in null', (() => {
         expectError(normalizer.reactView, normalizer, [null]).to.throw(expectedError);
-    })); 
+    }));
 
-    it('triggers an exception when passing in undefined', (() => { 
+    it('triggers an exception when passing in undefined', (() => {
         expect(normalizer.reactView, normalizer).to.throw(expectedError);
     }));
 
-    it('triggers an exception when passing in an object without a key property', (() => { 
+    it('triggers an exception when passing in an object without a key property', (() => {
         expectError(normalizer.reactView, normalizer, [{}]).to.throw(expectedError);
     }));
 
-    it('triggers an exception when passing in an object without a prop property', (() => { 
+    it('triggers an exception when passing in an object without a prop property', (() => {
         expectError(normalizer.reactView, normalizer, [{}]).to.throw(expectedError);
     }));
 
-    it('triggers an exception when passing in an object without a ref property', (() => { 
+    it('triggers an exception when passing in an object without a ref property', (() => {
         expectError(normalizer.reactView, normalizer, [{}]).to.throw(expectedError);
     }));
 
-    it('triggers a hint exception when passing in a reactComponent', (() => { 
+    it('triggers a hint exception when passing in a reactComponent', (() => {
         var testComponent = <br />;
 
         var hintException = "Looks like you passed in a react component.  Try using .reactComponent instead of .reactView.";
@@ -133,15 +133,16 @@ describe("Handling exceptions", (() => {
 }));
 
 describe("When using the normalier", (() => {
-  var normalizerDefalut, normalizerWitelistedAttributes, normalizerWhitelistedStyles, 
+  var normalizerDefalut, normalizerWhitelistedAttributes, normalizerBlacklistedAttributes, normalizerWhitelistedStyles,
   normalizerWhitelistedClassNames, normalizerNulls, normalizerEmptyAttributes, normalizerEmptyStyles, normalizerEmptyClasses;
-  var expectedNormal, expectedWhitelistedAttributes, expectedWhitelistedStyles, 
+  var expectedNormal, expectedWhitelistedAttributes, expectedBlacklistedAttributes, expectedWhitelistedStyles,
     expectedWhitelistedClassNames, expectedNulls, expectedEmptyAttributes, expectedEmptyStyles, expectedEmptyClasses;
 
 
   beforeEach(() => {
     expectedNormal = "<div><div class=\"spin glow auto\" style=\"display:block\">some text</div></div>";
     expectedWhitelistedAttributes = "<div><div data-a=\"something\" data-foo=\"bar\">some text</div></div>";
+    expectedBlacklistedAttributes = "<div><div data-a=\"something\">some text</div></div>";
     expectedWhitelistedStyles = "<div><div style=\"background:red; font-size:12px\">some text</div></div>";
     expectedNulls = "<div><div class=\"spin glow auto\" data-a=\"something\" data-foo=\"bar\" data-never=\"whitelisted\" style=\"background:red; display:block; font-size:12px\">some text</div></div>";
     expectedWhitelistedClassNames = "<div><div class=\"auto spin\">some text</div></div>";
@@ -150,7 +151,8 @@ describe("When using the normalier", (() => {
     expectedEmptyClasses = "<div><div style=\"display:block\">some text</div></div>";
 
     normalizerDefalut = new Normalizer();
-    normalizerWitelistedAttributes = new Normalizer({attributes: ["data-a", "data-foo"]});
+    normalizerWhitelistedAttributes = new Normalizer({attributes: ["data-a", "data-foo"]});
+    normalizerBlacklistedAttributes = new Normalizer({attributes: null, attributesExcluded: ["data-never", "data-foo", "style", "class"]});
     normalizerWhitelistedStyles = new Normalizer({attributes: ["style"], styles: ["font-size", "background"]});
     normalizerWhitelistedClassNames = new Normalizer({attributes: ["class"], classNames: ["spin", "auto"]});
     normalizerNulls = new Normalizer({attributes: null, styles: null, classNames: null});
@@ -159,78 +161,85 @@ describe("When using the normalier", (() => {
     normalizerEmptyClasses = new Normalizer({classNames: []});
 
   });
- 
+
 
   describe("and normalizing a dom string", (()=> {
     var domString;
 
     beforeEach(() => {
       domString = "<div><div data-never='whitelisted' data-foo='bar' data-a='something' style='font-size: 12px; background: red; display: block' class='spin glow auto'>some text</div></div>";
-    }); 
+    });
 
     describe("and calling the plymorphic method normalze", (() => {
       it('calls normalize string when passed a string', (() => {
         var spy = chai.spy.on(normalizerDefalut, 'domString');
         normalizerDefalut.normalize(domString);
-        expect(spy).to.have.been.called.with(domString); 
+        expect(spy).to.have.been.called.with(domString);
       }));
     }));
 
     describe("and it's configured with the default options", (()=> {
-      it('only retains the style and class attributes and removes all styles except display', (() => { 
+      it('only retains the style and class attributes and removes all styles except display', (() => {
         var normalized = normalizerDefalut.domString(domString);
-        assert.equal(normalized, expectedNormal); 
+        assert.equal(normalized, expectedNormal);
       }));
-    })); 
+    }));
 
     describe("and it's configured with whitelisted attributes", (()=> {
-      it('only retains the whitelisted attributes and sorts them in alphabetical order', (() => { 
-        var normalized = normalizerWitelistedAttributes.domString(domString);
-        assert.equal(normalized, expectedWhitelistedAttributes); 
+      it('only retains the whitelisted attributes and sorts them in alphabetical order', (() => {
+        var normalized = normalizerWhitelistedAttributes.domString(domString);
+        assert.equal(normalized, expectedWhitelistedAttributes);
       }));
-    })); 
+    }));
+
+    describe("and it's configured with blacklisted attributes", (()=> {
+      it('only retains the non blacklisted attributes and sorts them in alphabetical order', (() => {
+        var normalized = normalizerBlacklistedAttributes.domString(domString);
+        assert.equal(normalized, expectedBlacklistedAttributes);
+      }));
+    }));
 
     describe("and it's configured with whitelisted styles", (()=> {
-      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => { 
+      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => {
         var normalized = normalizerWhitelistedStyles.domString(domString);
-        assert.equal(normalized, expectedWhitelistedStyles); 
+        assert.equal(normalized, expectedWhitelistedStyles);
       }));
-    })); 
+    }));
 
     describe("and it's configured with whitelisted class names", (()=> {
-      it('only retains the whitelisted classNames and sorts them', (() => { 
+      it('only retains the whitelisted classNames and sorts them', (() => {
         var normalized = normalizerWhitelistedClassNames.domString(domString);
-        assert.equal(normalized, expectedWhitelistedClassNames); 
+        assert.equal(normalized, expectedWhitelistedClassNames);
       }));
-    })); 
+    }));
 
     describe("and it's configured with null attributes and styles", (()=> {
-      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => { 
+      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => {
         var normalized = normalizerNulls.domString(domString);
-        assert.equal(normalized, expectedNulls); 
+        assert.equal(normalized, expectedNulls);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty attributes", (()=> {
-      it('only renders markup with no attributes', (() => { 
+      it('only renders markup with no attributes', (() => {
         var normalized = normalizerEmptyAttributes.domString(domString);
-        assert.equal(normalized, expectedEmptyAttributes); 
+        assert.equal(normalized, expectedEmptyAttributes);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty styles", (()=> {
-      it('only renders markup with no styles', (() => { 
+      it('only renders markup with no styles', (() => {
         var normalized = normalizerEmptyStyles.domString(domString);
-        assert.equal(normalized, expectedEmptyStyles); 
+        assert.equal(normalized, expectedEmptyStyles);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty classNames", (()=> {
-      it('only renders markup with no classNames', (() => { 
+      it('only renders markup with no classNames', (() => {
         var normalized = normalizerEmptyClasses.domString(domString);
-        assert.equal(normalized, expectedEmptyClasses); 
+        assert.equal(normalized, expectedEmptyClasses);
       }));
-    })); 
+    }));
   }));
 
   describe("and normalizing a dom node", (()=> {
@@ -239,138 +248,152 @@ describe("When using the normalier", (() => {
     beforeEach(() => {
       domNode = document.createElement("div");
       domNode.innerHTML = "<div data-never='whitelisted' data-foo='bar' data-a='something' style='font-size: 12px; background: red; display: block' class='spin glow auto'>some text</div>";
-    }); 
+    });
 
 
     describe("and calling the plymorphic method normalze", (() => {
       it('calls normalize dom node when passed a string', (() => {
         var spy = chai.spy.on(normalizerDefalut, 'domNode');
         normalizerDefalut.normalize(domNode);
-        expect(spy).to.have.been.called.with(domNode); 
+        expect(spy).to.have.been.called.with(domNode);
       }));
     }));
 
     describe("and it's configured with the default options", (()=> {
-      it('only retains the style and class attributes and removes all styles except display', (() => { 
+      it('only retains the style and class attributes and removes all styles except display', (() => {
         var normalized = normalizerDefalut.domNode(domNode);
-        assert.equal(normalized, expectedNormal); 
+        assert.equal(normalized, expectedNormal);
       }));
-    })); 
+    }));
 
     describe("and it's configured with whitelisted attributes", (()=> {
-      it('only retains the whitelisted attributes and sorts them in alphabetical order', (() => { 
-        var normalized = normalizerWitelistedAttributes.domNode(domNode);
-        assert.equal(normalized, expectedWhitelistedAttributes); 
+      it('only retains the whitelisted attributes and sorts them in alphabetical order', (() => {
+        var normalized = normalizerWhitelistedAttributes.domNode(domNode);
+        assert.equal(normalized, expectedWhitelistedAttributes);
       }));
-    })); 
+    }));
+
+    describe("and it's configured with blacklisted attributes", (()=> {
+      it('only retains the non-blacklisted attributes and sorts them in alphabetical order', (() => {
+        var normalized = normalizerBlacklistedAttributes.domNode(domNode);
+        assert.equal(normalized, expectedBlacklistedAttributes);
+      }));
+    }));
 
     describe("and it's configured with whitelisted styles", (()=> {
-      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => { 
+      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => {
         var normalized = normalizerWhitelistedStyles.domNode(domNode);
-        assert.equal(normalized, expectedWhitelistedStyles); 
+        assert.equal(normalized, expectedWhitelistedStyles);
       }));
-    })); 
+    }));
 
     describe("and it's configured with null attributes and styles", (()=> {
-      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => { 
+      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => {
         var normalized = normalizerNulls.domNode(domNode);
-        assert.equal(normalized, expectedNulls); 
+        assert.equal(normalized, expectedNulls);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty attributes", (()=> {
-      it('only renders markup with no attributes', (() => { 
+      it('only renders markup with no attributes', (() => {
         var normalized = normalizerEmptyAttributes.domNode(domNode);
-        assert.equal(normalized, expectedEmptyAttributes); 
+        assert.equal(normalized, expectedEmptyAttributes);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty styles", (()=> {
-      it('only renders markup with no styles', (() => { 
+      it('only renders markup with no styles', (() => {
         var normalized = normalizerEmptyStyles.domNode(domNode);
-        assert.equal(normalized, expectedEmptyStyles); 
+        assert.equal(normalized, expectedEmptyStyles);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty classNames", (()=> {
-      it('only renders markup with no classNames', (() => { 
+      it('only renders markup with no classNames', (() => {
         var normalized = normalizerEmptyClasses.domNode(domNode);
-        assert.equal(normalized, expectedEmptyClasses); 
+        assert.equal(normalized, expectedEmptyClasses);
       }));
-    })); 
+    }));
   }));
- 
+
   describe("and normalizing a component", (()=> {
     var component;
 
     beforeEach(() => {
       component = (
         <div>
-          <div data-foo='bar' 
-          data-a='something' 
+          <div data-foo='bar'
+          data-a='something'
           data-never='whitelisted'
           style={{fontSize: 12, background: 'red', display: 'block'}}
           className='spin glow auto'>some text</div>
         </div>
       );
-    }); 
+    });
 
     describe("and calling the plymorphic method normalze", (() => {
       it('calls normalize react element when passed a string', (() => {
         var spy = chai.spy.on(normalizerDefalut, 'reactComponent');
         normalizerDefalut.normalize(component);
-        expect(spy).to.have.been.called.with(component); 
+        expect(spy).to.have.been.called.with(component);
       }));
     }));
 
     describe("and it's configured with the default options", (()=> {
-      it('only retains the style and class attributes and removes all styles except display', (() => { 
+      it('only retains the style and class attributes and removes all styles except display', (() => {
         var normalized = normalizerDefalut.reactComponent(component);
-        assert.equal(normalized, expectedNormal); 
+        assert.equal(normalized, expectedNormal);
       }));
-    })); 
+    }));
 
     describe("and it's configured with whitelisted attributes", (()=> {
-      it('only retains the whitelisted attributes and sorts them in alphabetical order', (() => { 
-        var normalized = normalizerWitelistedAttributes.reactComponent(component);
-        assert.equal(normalized, expectedWhitelistedAttributes); 
+      it('only retains the whitelisted attributes and sorts them in alphabetical order', (() => {
+        var normalized = normalizerWhitelistedAttributes.reactComponent(component);
+        assert.equal(normalized, expectedWhitelistedAttributes);
       }));
-    })); 
+    }));
+
+    describe("and it's configured with blacklisted attributes", (()=> {
+      it('only retains the non-blacklisted attributes and sorts them in alphabetical order', (() => {
+        var normalized = normalizerBlacklistedAttributes.reactComponent(component);
+        assert.equal(normalized, expectedBlacklistedAttributes);
+      }));
+    }));
 
     describe("and it's configured with whitelisted styles", (()=> {
-      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => { 
+      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => {
         var normalized = normalizerWhitelistedStyles.reactComponent(component);
-        assert.equal(normalized, expectedWhitelistedStyles); 
+        assert.equal(normalized, expectedWhitelistedStyles);
       }));
-    })); 
+    }));
 
     describe("and it's configured with null attributes and styles", (()=> {
-      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => { 
+      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => {
         var normalized = normalizerNulls.reactComponent(component);
-        assert.equal(normalized, expectedNulls); 
+        assert.equal(normalized, expectedNulls);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty attributes", (()=> {
-      it('only renders markup with no attributes', (() => { 
+      it('only renders markup with no attributes', (() => {
         var normalized = normalizerEmptyAttributes.reactComponent(component);
-        assert.equal(normalized, expectedEmptyAttributes); 
+        assert.equal(normalized, expectedEmptyAttributes);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty styles", (()=> {
-      it('only renders markup with no styles', (() => { 
+      it('only renders markup with no styles', (() => {
         var normalized = normalizerEmptyStyles.reactComponent(component);
-        assert.equal(normalized, expectedEmptyStyles); 
+        assert.equal(normalized, expectedEmptyStyles);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty classNames", (()=> {
-      it('only renders markup with no classNames', (() => { 
+      it('only renders markup with no classNames', (() => {
         var normalized = normalizerEmptyClasses.reactComponent(component);
-        assert.equal(normalized, expectedEmptyClasses); 
+        assert.equal(normalized, expectedEmptyClasses);
       }));
-    })); 
+    }));
   }));
 
   describe("and normalizing a react view", (()=> {
@@ -380,8 +403,8 @@ describe("When using the normalier", (() => {
       var TestView = React.createClass({
                 render(){
                   return (<div>
-                    <div data-foo='bar' 
-                    data-a='something' 
+                    <div data-foo='bar'
+                    data-a='something'
                     style={{fontSize: 12, background: 'red', display: 'block'}}
                     data-never='whitelisted'
                     className='spin glow auto'>some text</div>
@@ -392,63 +415,70 @@ describe("When using the normalier", (() => {
       view = TestUtils.renderIntoDocument(
           <TestView />
       );
-    }); 
+    });
 
     describe("and calling the plymorphic method normalze", (() => {
       it('calls normalize react element when passed a react view', (() => {
         var spy = chai.spy.on(normalizerDefalut, 'reactView');
         normalizerDefalut.normalize(view);
-        expect(spy).to.have.been.called.with(view); 
+        expect(spy).to.have.been.called.with(view);
       }));
     }));
 
     describe("and it's configured with the default options", (()=> {
-      it('only retains the style and class attributes and removes all styles except display', (() => { 
+      it('only retains the style and class attributes and removes all styles except display', (() => {
         var normalized = normalizerDefalut.reactView(view);
-        assert.equal(normalized, expectedNormal); 
+        assert.equal(normalized, expectedNormal);
       }));
-    })); 
+    }));
 
     describe("and it's configured with whitelisted attributes", (()=> {
-      it('only retains the whitelisted attributes and sorts them in alphabetical order', (() => { 
-        var normalized = normalizerWitelistedAttributes.reactView(view);
-        assert.equal(normalized, expectedWhitelistedAttributes); 
+      it('only retains the whitelisted attributes and sorts them in alphabetical order', (() => {
+        var normalized = normalizerWhitelistedAttributes.reactView(view);
+        assert.equal(normalized, expectedWhitelistedAttributes);
       }));
-    })); 
+    }));
+
+    describe("and it's configured with blacklisted attributes", (()=> {
+      it('only retains the non-blacklisted attributes and sorts them in alphabetical order', (() => {
+        var normalized = normalizerBlacklistedAttributes.reactView(view);
+        assert.equal(normalized, expectedBlacklistedAttributes);
+      }));
+    }));
 
     describe("and it's configured with whitelisted styles", (()=> {
-      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => { 
+      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => {
         var normalized = normalizerWhitelistedStyles.reactView(view);
-        assert.equal(normalized, expectedWhitelistedStyles); 
+        assert.equal(normalized, expectedWhitelistedStyles);
       }));
-    })); 
+    }));
 
     describe("and it's configured with null attributes and styles", (()=> {
-      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => { 
+      it('only retains the whitelisted styles and sorts them in alphabetical order', (() => {
         var normalized = normalizerNulls.reactView(view);
-        assert.equal(normalized, expectedNulls); 
+        assert.equal(normalized, expectedNulls);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty attributes", (()=> {
-      it('only renders markup with no attributes', (() => { 
+      it('only renders markup with no attributes', (() => {
         var normalized = normalizerEmptyAttributes.reactView(view);
-        assert.equal(normalized, expectedEmptyAttributes); 
+        assert.equal(normalized, expectedEmptyAttributes);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty styles", (()=> {
-      it('only renders markup with no styles', (() => { 
+      it('only renders markup with no styles', (() => {
         var normalized = normalizerEmptyStyles.reactView(view);
-        assert.equal(normalized, expectedEmptyStyles); 
+        assert.equal(normalized, expectedEmptyStyles);
       }));
-    })); 
+    }));
 
     describe("and it's configured with empty classNames", (()=> {
-      it('only renders markup with no classNames', (() => { 
+      it('only renders markup with no classNames', (() => {
         var normalized = normalizerEmptyClasses.reactView(view);
-        assert.equal(normalized, expectedEmptyClasses); 
+        assert.equal(normalized, expectedEmptyClasses);
       }));
-    })); 
+    }));
   }));
 }));

--- a/test/NormalizerSpec.js
+++ b/test/NormalizerSpec.js
@@ -151,7 +151,7 @@ describe("When using the normalier", (() => {
     expectedEmptyClasses = "<div><div style=\"display:block\">some text</div></div>";
 
     normalizerDefalut = new Normalizer();
-    normalizerWhitelistedAttributes = new Normalizer({attributes: ["data-a", "data-foo"]});
+    normalizerWhitelistedAttributes = new Normalizer({attributes: ["data-a", "data-foo"], attributesExcluded: null});
     normalizerBlacklistedAttributes = new Normalizer({attributes: null, attributesExcluded: ["data-never", "data-foo", "style", "class"]});
     normalizerWhitelistedStyles = new Normalizer({attributes: ["style"], styles: ["font-size", "background"]});
     normalizerWhitelistedClassNames = new Normalizer({attributes: ["class"], classNames: ["spin", "auto"]});


### PR DESCRIPTION
Just to complete @seangates initial work on the feature, so you could publish the changes, as we desperately need them! 😉 

Things that are done here:
- Updated initial code of Sean to handle `null` for attributedExcluded option;
- Updated Sean logic to ignore blacklisted attributes;
- Backed-up everything with tests;
- Updated Readme with this feature;
- Fixed misspelled 'normalizerWitelistedAttributes' variable in tests;

My sublime removed all trailing whitespaces from touched files, that's why this PR looks bigger than it is. If required, i can create a different PR without trailing whitespace being removed.

Cheers.
